### PR TITLE
Implement batch search that counts the number of hits

### DIFF
--- a/hoover/search/es.py
+++ b/hoover/search/es.py
@@ -18,15 +18,13 @@ def elasticsearch():
     except ConnectionError:
         raise SearchError('Could not connect to Elasticsearch.')
     except RequestError as e:
-        def extract_info(ex):
-            reason = 'reason unknown'
-            try:
-                if ex.info:
-                    reason = ex.info['error']['root_cause'][0]['reason']
-            except LookupError:
-                pass
-            return reason
-        raise SearchError('Elasticsearch failed: ' + extract_info(e))
+        reason = 'reason unknown'
+        try:
+            if e.info:
+                reason = e.info['error']['root_cause'][0]['reason']
+        except LookupError:
+            pass
+        raise SearchError('Elasticsearch failed: ' + reason)
     except NotFoundError:
         raise SearchError("Elasticsearch failed: Not found.")
 

--- a/hoover/search/es.py
+++ b/hoover/search/es.py
@@ -74,15 +74,7 @@ def _get_indices(collections):
 
 @convert_es_errors
 def batch_count(query_strings, collections, aggs=None):
-    def _serialize(object):
-        if object:
-            return json.dumps(
-                object,
-                separators=(',', ':'),
-            ).replace('\n', '')
-        return '{}'
-
-    def _build_query_lines(meta, query_string, aggs):
+    def _build_query_lines(query_string, meta={}, aggs=None):
         query = {
             "query": {
                 "query_string": {
@@ -93,14 +85,14 @@ def batch_count(query_strings, collections, aggs=None):
         }
         if aggs:
             query['aggs'] = aggs
-        return _serialize(meta) + "\n" + _serialize(query) + "\n"
+        return json.dumps(meta) + "\n" + json.dumps(query) + "\n"
 
     indices = _get_indices(collections)
 
-    body = "".join([
-        _build_query_lines(None, q, aggs)
+    body = "".join(
+        _build_query_lines(q, {}, aggs)
         for q in query_strings
-    ])
+    )
 
     rv = es.msearch(
         index=indices,

--- a/hoover/search/es.py
+++ b/hoover/search/es.py
@@ -168,11 +168,11 @@ def refresh():
 
 
 def count(collection_id):
-    es = Elasticsearch(settings.HOOVER_ELASTICSEARCH_URL)
-    try:
-        return es.count(index=_index_name(collection_id))['count']
-    except NotFoundError:
-        return None
+    with elasticsearch() as es:
+        try:
+            return es.count(index=_index_name(collection_id))['count']
+        except NotFoundError:
+            return None
 
 
 def aliases(collection_id):

--- a/hoover/search/es.py
+++ b/hoover/search/es.py
@@ -71,10 +71,14 @@ def _get_indices(collections):
     )
     return indices
 
-def batch_count(queries, collections, aggs=None):
-    def _build_query_lines(query, meta={}, aggs=None):
+def batch_count(query_strings, collections, aggs=None):
+    def _build_query_lines(query_string, meta={}, aggs=None):
         query_body = {
-            "query": query
+            "query": {
+                "query_string": {
+                    "query": query_string,
+                }
+            }
         }
         if aggs:
             query_body['aggs'] = aggs
@@ -84,7 +88,7 @@ def batch_count(queries, collections, aggs=None):
 
     body = "".join(
         _build_query_lines(q, {}, aggs)
-        for q in queries
+        for q in query_strings
     )
 
     with elasticsearch() as es:
@@ -95,8 +99,8 @@ def batch_count(queries, collections, aggs=None):
             search_type='count'
         )
 
-    for query, response in zip(queries, rv.get('responses', [])):
-        response['_query'] = query
+    for query_string, response in zip(query_strings, rv.get('responses', [])):
+        response['_query_string'] = query_string
 
     return rv
 

--- a/hoover/search/signals.py
+++ b/hoover/search/signals.py
@@ -2,4 +2,4 @@ from django.dispatch import Signal
 
 search = Signal(['request', 'collections', 'duration', 'success'])
 doc = Signal(['request', 'collection', 'doc_id', 'duration', 'success'])
-batch = Signal(['request', 'collections', 'duration', 'success', 'queries'])
+batch = Signal(['request', 'collections', 'duration', 'success', 'query_count'])

--- a/hoover/search/signals.py
+++ b/hoover/search/signals.py
@@ -2,3 +2,4 @@ from django.dispatch import Signal
 
 search = Signal(['request', 'collections', 'duration', 'success'])
 doc = Signal(['request', 'collection', 'doc_id', 'duration', 'success'])
+batch = Signal(['request', 'collections', 'duration', 'success', 'queries'])

--- a/hoover/search/views.py
+++ b/hoover/search/views.py
@@ -137,7 +137,7 @@ def batch(request):
     if not query_strings:
         return JsonResponse({'status': 'error', 'reason': "No items to be searched."})
     if len(query_strings) > 100:
-        query_strings = query_strings[:100]
+        return JsonResponse({'status': 'error', 'reason': "Too many queries. Limit is 100."})
 
     success = False
     try:

--- a/hoover/search/views.py
+++ b/hoover/search/views.py
@@ -153,9 +153,10 @@ def batch(request):
         return JsonResponse({'status': 'error', 'reason': e.reason})
 
     finally:
-        signals.search.send('hoover.batch', **{
+        signals.batch.send('hoover.batch', **{
             'request': request,
             'collections': collections,
             'duration': time() - t0,
             'success': success,
+            'queries': len(queries),
         })

--- a/hoover/search/views.py
+++ b/hoover/search/views.py
@@ -159,5 +159,5 @@ def batch(request):
             'collections': collections,
             'duration': time() - t0,
             'success': success,
-            'queries': len(query_strings),
+            'query_count': len(query_strings),
         })

--- a/hoover/search/views.py
+++ b/hoover/search/views.py
@@ -136,6 +136,8 @@ def batch(request):
         return JsonResponse({'status': 'error', 'reason': "No collections selected."})
     if not query_strings:
         return JsonResponse({'status': 'error', 'reason': "No items to be searched."})
+    if len(query_strings) > 100:
+        query_strings = query_strings[:100]
 
     success = False
     try:

--- a/hoover/search/views.py
+++ b/hoover/search/views.py
@@ -129,20 +129,20 @@ def batch(request):
     t0 = time()
     body = json.loads(request.body.decode('utf-8'))
     collections = collections_acl(request.user, body['collections'])
-    queries = body.get('queries')
+    query_strings = body.get('query_strings')
     aggs = body.get('aggs')
 
     if not collections:
         return JsonResponse({'status': 'error', 'reason': "No collections selected."})
-    if not queries:
+    if not query_strings:
         return JsonResponse({'status': 'error', 'reason': "No items to be searched."})
-    if len(queries) > 100:
+    if len(query_strings) > 100:
         return JsonResponse({'status': 'error', 'reason': "Too many queries. Limit is 100."})
 
     success = False
     try:
         res = es.batch_count(
-            queries,
+            query_strings,
             collections,
             aggs
         )
@@ -158,5 +158,5 @@ def batch(request):
             'collections': collections,
             'duration': time() - t0,
             'success': success,
-            'queries': len(queries),
+            'queries': len(query_strings),
         })

--- a/hoover/search/views.py
+++ b/hoover/search/views.py
@@ -122,3 +122,38 @@ def whoami(request):
             'logout': reverse('logout') + '?next=/',
         },
     })
+
+@csrf_exempt
+@limit_user
+def batch(request):
+    t0 = time()
+    body = json.loads(request.body.decode('utf-8'))
+    collections = collections_acl(request.user, body['collections'])
+    query_strings = body.get('query_strings')
+    aggs = body.get('aggs')
+
+    if not collections:
+        return JsonResponse({'status': 'error', 'reason': "No collections selected."})
+    if not query_strings:
+        return JsonResponse({'status': 'error', 'reason': "No items to be searched."})
+
+    success = False
+    try:
+        res = es.batch_count(
+            query_strings,
+            collections,
+            aggs
+        )
+        res['status'] = 'ok'
+        return JsonResponse(res)
+
+    except es.SearchError as e:
+        return JsonResponse({'status': 'error', 'reason': e.reason})
+
+    finally:
+        signals.search.send('hoover.batch', **{
+            'request': request,
+            'collections': collections,
+            'duration': time() - t0,
+            'success': success,
+        })

--- a/hoover/search/views.py
+++ b/hoover/search/views.py
@@ -129,20 +129,20 @@ def batch(request):
     t0 = time()
     body = json.loads(request.body.decode('utf-8'))
     collections = collections_acl(request.user, body['collections'])
-    query_strings = body.get('query_strings')
+    queries = body.get('queries')
     aggs = body.get('aggs')
 
     if not collections:
         return JsonResponse({'status': 'error', 'reason': "No collections selected."})
-    if not query_strings:
+    if not queries:
         return JsonResponse({'status': 'error', 'reason': "No items to be searched."})
-    if len(query_strings) > 100:
+    if len(queries) > 100:
         return JsonResponse({'status': 'error', 'reason': "Too many queries. Limit is 100."})
 
     success = False
     try:
         res = es.batch_count(
-            query_strings,
+            queries,
             collections,
             aggs
         )

--- a/hoover/search/views.py
+++ b/hoover/search/views.py
@@ -147,6 +147,7 @@ def batch(request):
             aggs
         )
         res['status'] = 'ok'
+        success = True
         return JsonResponse(res)
 
     except es.SearchError as e:

--- a/hoover/site/events.py
+++ b/hoover/site/events.py
@@ -40,14 +40,14 @@ if settings.HOOVER_EVENTS_DIR:
         )
 
     @receiver(search_signals.batch)
-    def on_batch(sender, request, collections, duration, success, queries, **kw):
+    def on_batch(sender, request, collections, duration, success, query_count, **kw):
         save(
             type='batch',
             username=request.user.get_username(),
             collections=[c.name for c in collections],
             duration=duration,
             success=success,
-            queries=queries,
+            query_count=query_count,
         )
 
     if installed.twofactor:

--- a/hoover/site/events.py
+++ b/hoover/site/events.py
@@ -39,6 +39,17 @@ if settings.HOOVER_EVENTS_DIR:
             success=success,
         )
 
+    @receiver(search_signals.batch)
+    def on_batch(sender, request, collection, duration, success, queries, **kw):
+        save(
+            type='batch',
+            username=request.user.get_username(),
+            collections=[collection.name],
+            duration=duration,
+            success=success,
+            queries=queries,
+        )
+
     if installed.twofactor:
         from django.contrib.auth import signals as auth_signals
         from ..contrib.twofactor import signals as twofactor_signals

--- a/hoover/site/events.py
+++ b/hoover/site/events.py
@@ -40,11 +40,11 @@ if settings.HOOVER_EVENTS_DIR:
         )
 
     @receiver(search_signals.batch)
-    def on_batch(sender, request, collection, duration, success, queries, **kw):
+    def on_batch(sender, request, collections, duration, success, queries, **kw):
         save(
             type='batch',
             username=request.user.get_username(),
-            collections=[collection.name],
+            collections=[c.name for c in collections],
             duration=duration,
             success=success,
             queries=queries,

--- a/hoover/site/urls.py
+++ b/hoover/site/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     url(r'^admin/', include(admin_site.urls)),
     url(r'^search$', views.search, name='search'),
     url(r'^whoami$', views.whoami, name='whoami'),
+    url(r'^batch$', views.batch, name='batch'),
     url(r'^collections$', views.collections, name='collections'),
     url(r'^(?s)doc/(?P<collection_name>[^/]+)/(?P<id>[^/]+)(?P<suffix>.*)$', views.doc),
 ]


### PR DESCRIPTION
The `batch` endpoint also takes the `aggs` given, so the UI could implement something involving [`cardinality`](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-aggregations-metrics-cardinality-aggregation.html).