### PR TITLE
set default operator to `AND` for batch search

### DIFF
--- a/hoover/search/es.py
+++ b/hoover/search/es.py
@@ -107,6 +107,7 @@ def batch_count(query_strings, collections, aggs=None):
             "query": {
                 "query_string": {
                     "query": query_string,
+                    "default_operator": "AND",
                 }
             }
         }


### PR DESCRIPTION
to match the queries that the UI is sending.