### PR TITLE
ui-next: use correct path for next.js's static export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.cache
 /hoover/search/static
 /.idea
+/.venv

--- a/hoover/search/ui.py
+++ b/hoover/search/ui.py
@@ -32,7 +32,7 @@ def file(request, filename):
     return create_response(resolve(filename))
 
 def doc_html(request, data):
-    with resolve('doc.html').open('rt', encoding='utf-8') as f:
+    with resolve('doc/index.html').open('rt', encoding='utf-8') as f:
         html = f.read()
 
     data_json = escapejs(json.dumps(data))


### PR DESCRIPTION
This is necessary for https://github.com/hoover/ui/pull/23, because of how next.js handles static export of `/doc` as `/doc/index.html`.