### PR TITLE
Disable TOTP token sync

### DIFF
--- a/hoover/site/settings/common.py
+++ b/hoover/site/settings/common.py
@@ -91,6 +91,8 @@ STATIC_URL = '/static/'
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 
+OTP_TOTP_SYNC = False
+
 HOOVER_ELASTICSEARCH_URL = 'http://localhost:9200'
 
 HOOVER_UPLOADS_URL = '/uploads/'


### PR DESCRIPTION
This means token drift is always zero, so phones must stay synchronized with Internet time. To reset drift for existing tokens, open up `./manage.py shell` for hoover-search and run this script:

```python
from django.contrib.auth import models
for user in models.User.objects.all():
    for token in user.totpdevice_set.all():
        if token.drift != 0:
            print('drift for', repr(token), 'was', token.drift)
            token.drift = 0
            token.save()
```