### PR TITLE
Use fake filename in http request to snoop

### DIFF
--- a/hoover/search/loaders/external.py
+++ b/hoover/search/loaders/external.py
@@ -58,6 +58,8 @@ class Document:
                 raise RuntimeError("Unexpected response {!r} for {!r}"
                     .format(resp, url))
 
+        if suffix.startswith('/raw/'):
+            suffix = '/raw/data'  # fake filename, prevents url encoding errors
         url_with_suffix = urljoin(url, suffix[1:])
         resp = requests.get(url_with_suffix)
         if 200 <= resp.status_code < 300:


### PR DESCRIPTION
In the liquid-nomad deployment, filenames with spaces arrive with the spaces decoded. When passed on to snoop they trigger a weird csrf error. This patch normalizes the filename so that no error is triggered. The correct filename is still returned to the user; this request only fetches the contents of the file.